### PR TITLE
Adds service files for systemd and a configuration file for rsyslog

### DIFF
--- a/package/config/sharelatex
+++ b/package/config/sharelatex
@@ -1,0 +1,4 @@
+SHARELATEX_CONFIG="/etc/sharelatex/settings.coffee" 
+NODE_ENV="production" 
+LATEX_PATH="/usr/local/texlive/2014/bin/x86_64-linux"
+PATH="/usr/local/texlive/2014/bin/x86_64-linux:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"

--- a/package/rsyslog/sharelatex.conf
+++ b/package/rsyslog/sharelatex.conf
@@ -1,0 +1,2 @@
+template(name="ShareLatex" type="string" string="/var/log/sharelatex/%programname%.log")
+:programname,contains,"sharelatex" ?ShareLatex

--- a/package/systemd/sharelatex-chat.service
+++ b/package/systemd/sharelatex-chat.service
@@ -9,7 +9,7 @@ StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=sharelatex-chat
 SyslogFacility=daemon
-Environment=SHARELATEX_CONFIG="/etc/sharelatex/settings.coffee" NODE_ENV=production PATH="/usr/local/texlive/2014/bin/x86_64-linux:${PATH}"
+EnvironmentFile=/etc/sharelatex/sharelatex
 ExecStart=/usr/bin/node /var/www/sharelatex/chat/app.js
 
 [Install]

--- a/package/systemd/sharelatex-chat.service
+++ b/package/systemd/sharelatex-chat.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=ShareLatex chat service
+After=syslog.target network.target auditd.service redis.service
+
+[Service]
+User=sharelatex
+Group=sharelatex
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=sharelatex-chat
+SyslogFacility=daemon
+Environment=SHARELATEX_CONFIG="/etc/sharelatex/settings.coffee" NODE_ENV=production PATH="/usr/local/texlive/2014/bin/x86_64-linux:${PATH}"
+ExecStart=/usr/bin/node /var/www/sharelatex/chat/app.js
+
+[Install]
+WantedBy=multi-user.target

--- a/package/systemd/sharelatex-clsi.service
+++ b/package/systemd/sharelatex-clsi.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=ShareLatex clsi service
+After=syslog.target network.target auditd.service redis.service
+
+[Service]
+User=sharelatex
+Group=sharelatex
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=sharelatex-clsi
+SyslogFacility=daemon
+Environment=SHARELATEX_CONFIG="/etc/sharelatex/settings.coffee" NODE_ENV=production PATH="/usr/local/texlive/2014/bin/x86_64-linux:${PATH}"
+ExecStart=/usr/bin/node /var/www/sharelatex/clsi/app.js
+
+[Install]
+WantedBy=multi-user.target

--- a/package/systemd/sharelatex-clsi.service
+++ b/package/systemd/sharelatex-clsi.service
@@ -9,7 +9,7 @@ StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=sharelatex-clsi
 SyslogFacility=daemon
-Environment=SHARELATEX_CONFIG="/etc/sharelatex/settings.coffee" NODE_ENV=production PATH="/usr/local/texlive/2014/bin/x86_64-linux:${PATH}"
+EnvironmentFile=/etc/sharelatex/sharelatex
 ExecStart=/usr/bin/node /var/www/sharelatex/clsi/app.js
 
 [Install]

--- a/package/systemd/sharelatex-docstore.service
+++ b/package/systemd/sharelatex-docstore.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=ShareLatex docstore service
+After=syslog.target network.target auditd.service redis.service
+
+[Service]
+User=sharelatex
+Group=sharelatex
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=sharelatex-docstore
+SyslogFacility=daemon
+Environment=SHARELATEX_CONFIG="/etc/sharelatex/settings.coffee" NODE_ENV=production PATH="/usr/local/texlive/2014/bin/x86_64-linux:${PATH}"
+ExecStart=/usr/bin/node /var/www/sharelatex/docstore/app.js
+
+[Install]
+WantedBy=multi-user.target

--- a/package/systemd/sharelatex-docstore.service
+++ b/package/systemd/sharelatex-docstore.service
@@ -9,7 +9,7 @@ StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=sharelatex-docstore
 SyslogFacility=daemon
-Environment=SHARELATEX_CONFIG="/etc/sharelatex/settings.coffee" NODE_ENV=production PATH="/usr/local/texlive/2014/bin/x86_64-linux:${PATH}"
+EnvironmentFile=/etc/sharelatex/sharelatex
 ExecStart=/usr/bin/node /var/www/sharelatex/docstore/app.js
 
 [Install]

--- a/package/systemd/sharelatex-document-updater.service
+++ b/package/systemd/sharelatex-document-updater.service
@@ -9,7 +9,7 @@ StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=sharelatex-document-updater
 SyslogFacility=daemon
-Environment=SHARELATEX_CONFIG="/etc/sharelatex/settings.coffee" NODE_ENV=production PATH="/usr/local/texlive/2014/bin/x86_64-linux:${PATH}"
+EnvironmentFile=/etc/sharelatex/sharelatex
 ExecStart=/usr/bin/node /var/www/sharelatex/document-updater/app.js
 
 [Install]

--- a/package/systemd/sharelatex-document-updater.service
+++ b/package/systemd/sharelatex-document-updater.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=ShareLatex document-updater service
+After=syslog.target network.target auditd.service redis.service
+
+[Service]
+User=sharelatex
+Group=sharelatex
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=sharelatex-document-updater
+SyslogFacility=daemon
+Environment=SHARELATEX_CONFIG="/etc/sharelatex/settings.coffee" NODE_ENV=production PATH="/usr/local/texlive/2014/bin/x86_64-linux:${PATH}"
+ExecStart=/usr/bin/node /var/www/sharelatex/document-updater/app.js
+
+[Install]
+WantedBy=multi-user.target

--- a/package/systemd/sharelatex-filestore.service
+++ b/package/systemd/sharelatex-filestore.service
@@ -9,7 +9,7 @@ StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=sharelatex-filestore
 SyslogFacility=daemon
-Environment=SHARELATEX_CONFIG="/etc/sharelatex/settings.coffee" NODE_ENV=production PATH="/usr/local/texlive/2014/bin/x86_64-linux:${PATH}"
+EnvironmentFile=/etc/sharelatex/sharelatex
 ExecStart=/usr/bin/node /var/www/sharelatex/filestore/app.js
 
 [Install]

--- a/package/systemd/sharelatex-filestore.service
+++ b/package/systemd/sharelatex-filestore.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=ShareLatex filestore service
+After=syslog.target network.target auditd.service redis.service
+
+[Service]
+User=sharelatex
+Group=sharelatex
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=sharelatex-filestore
+SyslogFacility=daemon
+Environment=SHARELATEX_CONFIG="/etc/sharelatex/settings.coffee" NODE_ENV=production PATH="/usr/local/texlive/2014/bin/x86_64-linux:${PATH}"
+ExecStart=/usr/bin/node /var/www/sharelatex/filestore/app.js
+
+[Install]
+WantedBy=multi-user.target

--- a/package/systemd/sharelatex-spelling.service
+++ b/package/systemd/sharelatex-spelling.service
@@ -9,7 +9,7 @@ StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=sharelatex-spelling
 SyslogFacility=daemon
-Environment=SHARELATEX_CONFIG="/etc/sharelatex/settings.coffee" NODE_ENV=production PATH="/usr/local/texlive/2014/bin/x86_64-linux:${PATH}"
+EnvironmentFile=/etc/sharelatex/sharelatex
 ExecStart=/usr/bin/node /var/www/sharelatex/spelling/app.js
 
 [Install]

--- a/package/systemd/sharelatex-spelling.service
+++ b/package/systemd/sharelatex-spelling.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=ShareLatex spelling service
+After=syslog.target network.target auditd.service redis.service
+
+[Service]
+User=sharelatex
+Group=sharelatex
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=sharelatex-spelling
+SyslogFacility=daemon
+Environment=SHARELATEX_CONFIG="/etc/sharelatex/settings.coffee" NODE_ENV=production PATH="/usr/local/texlive/2014/bin/x86_64-linux:${PATH}"
+ExecStart=/usr/bin/node /var/www/sharelatex/spelling/app.js
+
+[Install]
+WantedBy=multi-user.target

--- a/package/systemd/sharelatex-tags.service
+++ b/package/systemd/sharelatex-tags.service
@@ -9,7 +9,7 @@ StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=sharelatex-tags
 SyslogFacility=daemon
-Environment=SHARELATEX_CONFIG="/etc/sharelatex/settings.coffee" NODE_ENV=production PATH="/usr/local/texlive/2014/bin/x86_64-linux:${PATH}"
+EnvironmentFile=/etc/sharelatex/sharelatex
 ExecStart=/usr/bin/node /var/www/sharelatex/tags/app.js
 
 [Install]

--- a/package/systemd/sharelatex-tags.service
+++ b/package/systemd/sharelatex-tags.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=ShareLatex tags service
+After=syslog.target network.target auditd.service redis.service
+
+[Service]
+User=sharelatex
+Group=sharelatex
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=sharelatex-tags
+SyslogFacility=daemon
+Environment=SHARELATEX_CONFIG="/etc/sharelatex/settings.coffee" NODE_ENV=production PATH="/usr/local/texlive/2014/bin/x86_64-linux:${PATH}"
+ExecStart=/usr/bin/node /var/www/sharelatex/tags/app.js
+
+[Install]
+WantedBy=multi-user.target

--- a/package/systemd/sharelatex-track-changes.service
+++ b/package/systemd/sharelatex-track-changes.service
@@ -9,7 +9,7 @@ StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=sharelatex-track-changes
 SyslogFacility=daemon
-Environment=SHARELATEX_CONFIG="/etc/sharelatex/settings.coffee" NODE_ENV=production PATH="/usr/local/texlive/2014/bin/x86_64-linux:${PATH}"
+EnvironmentFile=/etc/sharelatex/sharelatex
 ExecStart=/usr/bin/node /var/www/sharelatex/track-changes/app.js
 
 [Install]

--- a/package/systemd/sharelatex-track-changes.service
+++ b/package/systemd/sharelatex-track-changes.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=ShareLatex track-changes service
+After=syslog.target network.target auditd.service redis.service
+
+[Service]
+User=sharelatex
+Group=sharelatex
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=sharelatex-track-changes
+SyslogFacility=daemon
+Environment=SHARELATEX_CONFIG="/etc/sharelatex/settings.coffee" NODE_ENV=production PATH="/usr/local/texlive/2014/bin/x86_64-linux:${PATH}"
+ExecStart=/usr/bin/node /var/www/sharelatex/track-changes/app.js
+
+[Install]
+WantedBy=multi-user.target

--- a/package/systemd/sharelatex-web.service
+++ b/package/systemd/sharelatex-web.service
@@ -9,7 +9,7 @@ StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=sharelatex-web
 SyslogFacility=daemon
-Environment=SHARELATEX_CONFIG="/etc/sharelatex/settings.coffee" NODE_ENV=production PATH="/usr/local/texlive/2014/bin/x86_64-linux:${PATH}"
+EnvironmentFile=/etc/sharelatex/sharelatex
 ExecStart=/usr/bin/node /var/www/sharelatex/web/app.js
 
 [Install]

--- a/package/systemd/sharelatex-web.service
+++ b/package/systemd/sharelatex-web.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=ShareLatex web service
+After=syslog.target network.target auditd.service redis.service mongod.service
+
+[Service]
+User=sharelatex
+Group=sharelatex
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=sharelatex-web
+SyslogFacility=daemon
+Environment=SHARELATEX_CONFIG="/etc/sharelatex/settings.coffee" NODE_ENV=production PATH="/usr/local/texlive/2014/bin/x86_64-linux:${PATH}"
+ExecStart=/usr/bin/node /var/www/sharelatex/web/app.js
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Enables start/stop/status and such with systemd based distributions. Logging is done trough daemon syslog facility using an identifier for each service.
The rsyslog file configuration (to be copied in /etc/rsyslog.d/) takes this identifier and fills the appropriate file under /var/log/sharelatex/ dierctory.
Environment variable are defined in a file (/etc/sharelatex/sharelatex) as all services are  using the same variables.