### PR TITLE
Missing restart for real-time service

### DIFF
--- a/package/scripts/after_install.sh
+++ b/package/scripts/after_install.sh
@@ -24,3 +24,4 @@ service sharelatex-docstore restart
 service sharelatex-chat restart
 service sharelatex-tags restart
 service sharelatex-spelling restart
+service sharelatex-real-time restart


### PR DESCRIPTION
It's seems the real-time service is missing from the after_install script, I hadn't web sockets features because the script didn't start the service :(