### PR TITLE
Cope with lettered versions of latexmk

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -336,7 +336,7 @@ module.exports = (grunt) ->
 						error = new Error("Unknown latexmk version")
 					else
 						version = m[1]
-						if semver.gte(version + ".0", "4.39.0")
+						if semver.gte(version.replace(/[a-z]$/, "") + ".0", "4.39.0")
 							grunt.log.writeln "OK."
 							grunt.log.writeln "Running latexmk version #{version}"
 						else


### PR DESCRIPTION
This works around latexmk's non-standard version numbering, properly fixing issue #302 and avoiding a confusing error message.
