### PR TITLE
Replace grunt service initialisation with bash script

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -87,9 +87,11 @@ module.exports = (grunt) ->
 	grunt.registerTask 'install:all', "Download and set up all ShareLaTeX services",
 		[].concat(
 			("install:#{service.name}" for service in SERVICES)
-		)
+		).concat(['postinstall'])
 
 	grunt.registerTask 'install', 'install:all'
+	grunt.registerTask 'postinstall', 'Explain postinstall steps', () ->
+		Helpers.postinstallMessage @async()
 
 	grunt.registerTask 'update:all', "Checkout and update all ShareLaTeX services",
 		["check:make"].concat(
@@ -146,6 +148,17 @@ module.exports = (grunt) ->
 			proc = spawn "git", ["checkout", service.version], stdio: "inherit", cwd: dir
 			proc.on "close", () ->
 				callback()
+
+		postinstallMessage: (callback = (error) ->) ->
+			grunt.log.write """
+			Services cloned:
+				#{service.name for service in SERVICES}
+			To install services run:
+				$ source bin/install-services
+			This will install the required node versions and run `npm install` for each service.
+			See https://github.com/sharelatex/sharelatex/pull/549 for more info.
+			"""
+			callback()
 
 		checkMake: (callback = (error) ->) ->
 			grunt.log.write "Checking make is installed... "

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -120,16 +120,10 @@ module.exports = (grunt) ->
 		installService: (service, callback = (error) ->) ->
 			console.log "Installing #{service.name}"
 			Helpers.cloneGitRepo service, (error) ->
-				return callback(error) if error?
-				Helpers.installNpmModules service, (error) ->
-					return callback(error) if error?
-					Helpers.rebuildNpmModules service, (error) ->
-						return callback(error) if error?
-						Helpers.runGruntInstall service, (error) ->
-							return callback(error) if error?
-							console.log "Finished installing #{service.name}"
-							callback()
-
+				if error?
+					callback(error)
+				else
+					callback()
 
 		cloneGitRepo: (service, callback = (error) ->) ->
 			repo_src = service.repo
@@ -150,27 +144,6 @@ module.exports = (grunt) ->
 			dir = service.name
 			grunt.log.write "checking out #{service.name} #{service.version}"
 			proc = spawn "git", ["checkout", service.version], stdio: "inherit", cwd: dir
-			proc.on "close", () ->
-				callback()
-
-
-		installNpmModules: (service, callback = (error) ->) ->
-			dir = service.name
-			proc = spawn "npm", ["install"], stdio: "inherit", cwd: dir
-			proc.on "close", () ->
-				callback()
-
-		# work around for https://github.com/npm/npm/issues/5400
-		# where binary modules are not built due to bug in npm
-		rebuildNpmModules: (service, callback = (error) ->) ->
-			dir = service.name
-			proc = spawn "npm", ["rebuild"], stdio: "inherit", cwd: dir
-			proc.on "close", () ->
-				callback()
-
-		runGruntInstall: (service, callback = (error) ->) ->
-			dir = service.name
-			proc = spawn "grunt", ["install"], stdio: "inherit", cwd: dir
 			proc.on "close", () ->
 				callback()
 

--- a/bin/install-services
+++ b/bin/install-services
@@ -5,8 +5,11 @@ grep 'name:' config/services.js | \
 	while read service
 	do
 		pushd $service &&
+		echo "Installing Service $service" &&
+		echo '  installing Node' &&
 		nvm install &&
 		nvm use &&
+		echo '  installing Dependencies' &&
 		npm install
 		popd
 	done

--- a/bin/install-services
+++ b/bin/install-services
@@ -1,0 +1,12 @@
+#! env bash
+
+grep 'name:' config/services.js | \
+	sed 's/.*name: "\(.*\)",/\1/' | \
+	while read service
+	do
+		pushd $service &&
+		nvm install &&
+		nvm use &&
+		npm install
+		popd
+	done


### PR DESCRIPTION
At the moment the `grunt install` task clones all services and runs `npm install` but it doesn't respect the node version of the given service. Some of the binaries can be different between node versions so to get everything working I had to remove `node_modules` files in each service and run `nvm install && npm install`.

Nvm isn't accessible through the processes spawned by grunt because it's reliant on special configuration in the users shell config.

This PR does two things:
1. remove the parts of the grunt task which run `npm install`
1. add a shell script which can be sourced, which runs `nvm install && npm install` for each service. I went with `nvm install` as this is a one off configuration task

I'm unsure on what documentation if any to update