### PR TITLE
check for nvm presence before using, survive abscence

### DIFF
--- a/bin/install-services
+++ b/bin/install-services
@@ -4,12 +4,12 @@ grep 'name:' config/services.js | \
 	sed 's/.*name: "\(.*\)",/\1/' | \
 	while read service
 	do
-		pushd $service &&
-		echo "Installing Service $service" &&
-		echo '  installing Node' &&
-		nvm install &&
-		nvm use &&
-		echo '  installing Dependencies' &&
+		pushd $service
+		echo "Installing Service $service"
+		echo '  installing Node'
+		type nvm && nvm install
+		type nvm && nvm use
+		echo '  installing Dependencies'
 		npm install
 		popd
 	done

--- a/bin/install-services
+++ b/bin/install-services
@@ -1,5 +1,14 @@
 #! env bash
 
+[ -z "`type -t nvm`" ] && cat <<EOF
+
+==========================================================
+== NVM not installed, you should consider installing it ==
+==========================================================
+
+EOF
+
+
 grep 'name:' config/services.js | \
 	sed 's/.*name: "\(.*\)",/\1/' | \
 	while read service

--- a/bin/install-services
+++ b/bin/install-services
@@ -7,8 +7,8 @@ grep 'name:' config/services.js | \
 		pushd $service
 		echo "Installing Service $service"
 		echo '  installing Node'
-		type nvm && nvm install
-		type nvm && nvm use
+		type -t nvm && nvm install
+		type -t nvm && nvm use
 		echo '  installing Dependencies'
 		npm install
 		popd


### PR DESCRIPTION
Currently, the `install-services` script will fail if it is run without `nvm` available on the system. An example of this would be the docker-image builds for ShareLaTeX Server Pro and Community Edition.

If `nvm` is not available then installation should just proceed without it, using whatever the system `node` environment is.