### PR TITLE
Update CLA and other links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,37 +23,29 @@ If you can include a screenshot for front end issues that is very helpful.
 Pull Requests
 -------------
 
-See [our wiki](https://github.com/sharelatex/sharelatex/wiki/Developer-Guidelines)
+See [our wiki](https://github.com/sharelatex/sharelatex/wiki)
 for how to manage the ShareLaTeX development environment and for our developer guidelines.
 
 We love pull requests, so be bold with them! Don't be afraid of going ahead
 and changing something, or adding a new feature. We're very happy to work with you
 to get your changes merged into ShareLaTeX.
 
-If you're looking for something to work on, then take a look at our [development roadmap](https://github.com/sharelatex/sharelatex/wiki/Development-Roadmap), or have a look at the open issues in any of the repositories listed [here](https://github.com/sharelatex/sharelatex/blob/master/README.md#other-repositories).
-
-Developer Chat Room
--------------------
-
-If you want to ask any questions in real-time, or get a feel for what's going on
-then please drop into our [development chat room](http://www.hipchat.com/g1nJMcj7b).
-If no one is online then you can still leave a message that will hopefully get a reply
-when we return.
+If you're looking for something to work on, have a look at the open issues in any of the repositories listed [here](https://github.com/sharelatex/sharelatex/blob/master/README.md#other-repositories).
 
 Security
 --------
 
 Please do not publish security vulnerabilities publicly until we've had a chance
 to address them. All security related issues/patches should be sent directly to
-team@sharelatex.com where we will attempt to address them quickly. If you're
+security@overleaf.com where we will attempt to address them quickly. If you're
 unsure whether something is a security issue or not, then please be cautious and
-contact us at team@sharelatex.com first.
+contact us at security@overleaf.com first.
 
 Contributor License Agreement
 -----------------------------
 
 Before we can accept any contributions of code, we need you to agree to our 
-[Contributor License Agreement](https://sharelatex.wufoo.com/forms/sharelatex-contributor-license-agreement/).
+[Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLSef79XH3mb7yIiMzZw-yALEegS-wyFetvjTiNBfZvf_IHD2KA/viewform?usp=sf_link).
 This is to ensure that you own the copyright of your contribution, and that you
 agree to give us a license to use it in both the open source version, and the version
-of ShareLaTeX running at www.sharelatex.com, which may have additional changes.
+of Overleaf running at www.overleaf.com, which may have additional changes.


### PR DESCRIPTION
As part of consolidating survey providers, I've moved the CLA form to Google Docs. Also tidied up a few other things in this file.

CC @henryoswald 